### PR TITLE
typo in OCaml site URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@ development, and contributions or suggestions are welcome.
 <h2>Close Cousins of the SML Family</h2>
 <UL>
   <LI>
-  <A HREF="http:://ocaml.org"><strong>OCaml</strong></A>
+  <A HREF="http://ocaml.org"><strong>OCaml</strong></A>
   <P>OCaml is an industrial strength programming language supporting functional,
   imperative and object-oriented styles.  It is a close relative of the SML
   family that is enjoying considerable adoption in industry, and inspiring new


### PR DESCRIPTION
Ever so small typo, makes the link appear as "http://sml-family.org/://ocaml.org".
The browser then tries to load the page ://ocaml.org from the web site sml-family.org, which does not exist.
